### PR TITLE
Update tl_hc_mailchimp.xlf

### DIFF
--- a/languages/en/tl_hc_mailchimp.xlf
+++ b/languages/en/tl_hc_mailchimp.xlf
@@ -69,16 +69,16 @@
 				<source>You must fill all required fields (*).</source>
 			</trans-unit>
 			<trans-unit id="tl_hc_mailchimp.error232">
-				<source>Your email address don\'t exist in our List.</source>
+				<source>Your email address don't exist in our List.</source>
 			</trans-unit>
 			<trans-unit id="tl_hc_mailchimp.error215">
-				<source>Please insert a valid email address.';</source>
+				<source>Please insert a valid email address.</source>
 			</trans-unit>
 			<trans-unit id="tl_hc_mailchimp.archiveerror">
-				<source>No campaign are available.';</source>
+				<source>No campaign are available.</source>
 			</trans-unit>
 			<trans-unit id="tl_hc_mailchimp.subscribers">
-				<source>Subscribers';</source>
+				<source>Subscribers</source>
 			</trans-unit>
 		</body>
 	</file>


### PR DESCRIPTION
Es gab folgenden Fehler im Backend:
`Parse error: syntax error, unexpected T_STRING in 
/var/www/SGV/system/modules/core/library/Contao/System.php(291) : 
eval()'d code on line 25`
